### PR TITLE
add xfce4 terminal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN \
     make \
     tar \
     thunar \
+    xfce4-terminal \
     zlib1g && \
   echo "**** compile qdirstat ****" && \
   mkdir -p /tmp/qdirstat && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -22,6 +22,7 @@ RUN \
     make \
     tar \
     thunar \
+    xfce4-terminal \
     zlib1g && \
   echo "**** compile qdirstat ****" && \
   mkdir -p /tmp/qdirstat && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -22,6 +22,7 @@ RUN \
     make \
     tar \
     thunar \
+    xfce4-terminal \
     zlib1g && \
   echo "**** compile qdirstat ****" && \
   mkdir -p /tmp/qdirstat && \

--- a/README.md
+++ b/README.md
@@ -230,5 +230,6 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **06.04.22:** - Add xfce terminal.
 * **13.01.22:** - Compile from source.
 * **11.01.22:** - Initial release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -44,5 +44,6 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "06.04.22:", desc: "Add xfce terminal." }
   - { date: "13.01.22:", desc: "Compile from source." }
   - { date: "11.01.22:", desc: "Initial release." }

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -2,6 +2,7 @@
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
 <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
+<item label="XFCE Terminal" icon="/usr/share/icons/Humanity/apps/128/utilities-terminal.svg"><action name="Execute"><command>/usr/bin/xfce4-terminal</command></action></item>
 <item label="QDirStat" icon="/usr/share/icons/hicolor/scalable/apps/qdirstat.svg"><action name="Execute"><command>/bin/qdirstat</command></action></item>
 <item label="Reload OB"><action name="Reconfigure"/></item>
 </menu>


### PR DESCRIPTION
closes #4 

I cannot determine why it does not actually open in the folder selected though I suspect that is upstream. We should have their expected default terminal installed instead of messing with config files to launch xterm. 